### PR TITLE
Added capability to get all paths for directed graph and specific target

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 
 
-Copyright (c) 2018-2019, daniel.
+Copyright (c) 2018-2019, 2021, daniel.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/src/collection/index.js
+++ b/src/collection/index.js
@@ -1,4 +1,10 @@
-module.exports = function({maxPaths = -1, rootIds = []} = {}) {
+module.exports = {
+  allPaths,
+  allPathsTo
+};
+
+function allPaths({maxPaths = -1, rootIds = [], directed = false, target = null} = {}) {
+
   let eles = this;
   let cy = this.cy();
 
@@ -26,7 +32,19 @@ module.exports = function({maxPaths = -1, rootIds = []} = {}) {
       return;
     }
 
-    let nextEles = getOutgoers(node);
+    if (directed && target !== null && target === node.id()){
+      // It's the ending node in directed graph
+      allPaths.push(preNodes);
+      return;
+    }
+
+    let nextEles;
+    if(!directed){
+      nextEles = getOutgoers(node);
+    } else {
+      nextEles = getDirectedOutgoers(node, preNodes);
+    }
+
     if (nextEles.length === 0) {
       // It's the ending node
       allPaths.push(preNodes);
@@ -42,10 +60,46 @@ module.exports = function({maxPaths = -1, rootIds = []} = {}) {
     }
   }
 
+  function getDirectedOutgoers(node, preNodes){
+
+    let outgoers = node.outgoers();
+
+    let pos = -1;
+    for(let i = 0; i < outgoers.length; i++){
+      
+      // outgoers is node and node is already inside preNodes (visited)
+      if(i % 2 !== 0 && preNodes.find( (item) => { return item.id() === outgoers[i].id() })){
+        // save the position
+        pos = i;
+        break;
+      }
+    }
+
+    // delete edge and node
+    if( pos > -1)
+      outgoers.splice(pos - 1, 2);
+
+    let nextEles = []; // [[edge, node], ...]
+    let eles = []; // [edge, node]
+    outgoers.forEach((oEle, idx) => {
+      if (idx % 2 == 0) {
+        // even
+        eles = [];
+        eles.push(oEle);
+      } else {
+        // odd
+        eles.push(oEle);
+        nextEles.push(eles);
+      }
+    });
+    return nextEles;
+
+  }
+
   function getOutgoers(node) {
     let outgoers = node.outgoers();
-    let nextEles = []; // [[node, edge], ...]
-    let eles = []; // [node, edge]
+    let nextEles = []; // [[edge, node], ...]
+    let eles = []; // [edge, node]
     outgoers.forEach((oEle, idx) => {
       if (idx % 2 == 0) {
         // even
@@ -68,3 +122,8 @@ module.exports = function({maxPaths = -1, rootIds = []} = {}) {
 
   return allPathsCollection; // chainability
 };
+
+function allPathsTo(target, {maxPaths = -1, rootIds = []}){
+
+  return allPaths.apply(this, [Object.assign({maxPaths, rootIds}, {target, directed: true})]);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ const impl = require('./collection');
 let register = function( cytoscape ){
   if( !cytoscape ){ return; } // can't register if cytoscape unspecified
 
-  cytoscape( 'collection', 'cytoscapeAllPaths', impl ); // register with cytoscape.js
+  cytoscape( 'collection', 'cytoscapeAllPaths', impl.allPaths ); // register with cytoscape.js
+  cytoscape( 'collection', 'cytoscapeAllPathsTo', impl.allPathsTo)
 };
 
 if( typeof cytoscape !== 'undefined' ){ // expose to global cytoscape (i.e. window.cytoscape)


### PR DESCRIPTION
This modifications allows to get all paths from roots to specific target.

New options added:

- **directed**: boolean. default: false
- **target**: string. default: null

New method added:

cytoscapeAllPathsTo(target, settings)

- **target**: string. The target node ID
- **settings**: object. The existing settings object with keys rootIds and maxPaths

cytoscapeAllPathsTo is an alias of cytoscapeAllPaths({directed: true, target: "YOUR_TARGET", ...})